### PR TITLE
Add `forall` to help avoid the use of `...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ us to match all the possibilities either explicitly or by using a wildcard.
 
 Use `...` (ellipsis) for the wildcard.
 
-> TIP: Create the matcher at compile-time to have compile-time validation and zero runtime cost.
+
+> ***TIPs***
+> 
+> - Avoid the use of `...` (wildcard) to make sure any modification to the enums are safe.
+> - Create the matcher at compile-time to have compile-time validation and zero runtime cost.
 
 
-Example
--------
+Example: Flat matcher
+---------------------
 
 ```python
 from enum import Enum, auto
@@ -44,4 +48,28 @@ assert matcher2[Side.right] == "Go right"
 # If all the possibilities are not handled, we get error
 with pytest.raises(ValueError, match="missing possibilities: Side.right"):
     match({Side.left: "Go left"})
+```
+
+
+Example: Nested matcher
+-----------------------
+
+```python
+from enum import Enum, auto
+from enumatch import match, forall
+
+class Switch(Enum):
+    on = auto()
+    off = auto()
+
+# is_on[main_switch][bedroom_switch]: bool
+is_on = match({
+    Switch.on: match({Switch.on: True, Switch.off: False}),
+    Switch.off: forall(Switch, False),
+})
+
+assert is_on[Switch.on][Switch.on] == True
+assert is_on[Switch.on][Switch.off] == False
+assert is_on[Switch.off][Switch.on] == False
+assert is_on[Switch.off][Switch.off] == False
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enumatch"
-version = "0.1.4"  # Also update __init__.py
+version = "0.2.0"  # Also update __init__.py
 description = "Strictly match all the possibilities of an enum"
 license = "MIT"
 keywords = ["enum", "match", "functional"]

--- a/tests/test_enumatch.py
+++ b/tests/test_enumatch.py
@@ -1,6 +1,7 @@
 import pytest
 from enum import Enum
-from enumatch import match
+from enumatch import match, forall
+import typing as t
 
 
 class Color(Enum):
@@ -51,3 +52,38 @@ def test_match_invalid_input() -> None:
         TypeError, match="the first key of the given dict must be an enum attribute"
     ):
         match({...: (255, 0, 0), Color.green: (0, 255, 0), Color.blue: (0, 0, 255)})
+
+
+def test_nested() -> None:
+
+    # matcher[r][g][b]: (int, int, int)
+    matcher = match(
+        {
+            Color.red: match(
+                {
+                    Color.red: forall(Color, (255, 0, 0)),
+                    Color.green: match(
+                        {
+                            Color.red: (255, 255, 0),
+                            Color.green: (255, 255, 0),
+                            Color.blue: (255, 255, 255),
+                        }
+                    ),
+                    Color.blue: forall(Color, (255, 0, 0)),
+                }
+            ),
+            Color.green: forall(Color, forall(Color, (0, 0, 0))),
+            Color.blue: forall(Color, forall(Color, (0, 0, 0))),
+        }
+    )
+
+    assert matcher[Color.red][Color.green][Color.blue] == (255, 255, 255)
+
+    assert matcher[Color.red][Color.green][Color.red] == (255, 255, 0)
+    assert matcher[Color.red][Color.green][Color.green] == (255, 255, 0)
+
+    assert matcher[Color.red][Color.blue][Color.blue] == (255, 0, 0)
+    assert matcher[Color.red][Color.red][Color.blue] == (255, 0, 0)
+
+    assert matcher[Color.green][Color.green][Color.blue] == (0, 0, 0)
+    assert matcher[Color.blue][Color.green][Color.blue] == (0, 0, 0)


### PR DESCRIPTION
Suggest prefer using `forall` over wildcard cases.